### PR TITLE
Implement fully-automated extraction from an offline Windows system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # scripts
 Random scripts
+
+## samreader
+
+To run the script, use the following command:
+
+```bash
+python3 -m sam.samreader
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+hashcat
+pycryptodomex
+termcolor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 hashcat
 pycryptodomex
+python-registry
 termcolor


### PR DESCRIPTION
Hi!

First of all thanks for the two videos about the topics in these scripts, nice work!

I wanted to see if it was possible to extract the required values directly off of an offline Windows installation. I found [python-registry](https://github.com/williballenthin/python-registry/) which implements reading the registry hives directly out of System32 if the user has read-only access to the required files.

I tested this on a Linux system by mounting the Windows drive to `/mnt`:

```bash
$ python3 -m sam.samreader --sys32-config /mnt/Windows/System32/config

LSA key:
🔑 0x...

Boot key:
🔐 0x...

[...]
```

This PR:

- Adds `requirements.txt` since it was missing
- Makes the samreader script runnable as a module entrypoint since running it directly causes import problems — I'm not sure how you were running it
- Implements loading all values (LSA key and SAM info) directly off of `System32\config\{SAM,SYSTEM}`, without going through the annoying PDF print process and registry export.
